### PR TITLE
Issue 30

### DIFF
--- a/cypress/integration/e2e-fetch-question.spec.js
+++ b/cypress/integration/e2e-fetch-question.spec.js
@@ -66,6 +66,14 @@ describe("Fetch Questions from Stackoverflow", () => {
       });
   });
 
+  it("tag has right href pointing to tag's Stackoverflow page", () => {
+    cy.get('[data-test="tag_value"]').should(
+      "have.prop",
+      "href",
+      "https://stackoverflow.com/questions/tagged/javascript"
+    );
+  });
+
   it("input field loads & contains right placeholder value", () => {
     cy.get('[data-test="question_input"]')
       .should("exist")

--- a/src/components/QuestionInfo.vue
+++ b/src/components/QuestionInfo.vue
@@ -44,7 +44,7 @@
           v-for="questionTags in allQuestions[0].tags.slice(1, 5)"
           :key="questionTags"
         >
-          <BaseTag :tag-name="questionTags" />
+          <BaseTag :tag-name="questionTags" :isLabelVisible="false" />
         </span>
       </div>
     </div>

--- a/src/components/base-components/BaseForm.vue
+++ b/src/components/base-components/BaseForm.vue
@@ -19,7 +19,7 @@ export default {
     };
   },
   methods: {
-    handleInput: function () {
+    handleInput() {
       this.$emit("handleInputForm", this.inputValue);
       this.inputValue = "";
     },

--- a/src/components/base-components/BaseTag.vue
+++ b/src/components/base-components/BaseTag.vue
@@ -1,8 +1,14 @@
 <template>
   <div :class="this.classProps">
-    <span class="tag_value px-3 py-1 ml-2" data-test="tag_value">
+    <span class="tag_label mr-1" v-if="isLabelVisible">Current Tag:</span>
+    <a
+      class="tag_value px-3 py-1 ml-2"
+      data-test="tag_value"
+      :href="tagUrl"
+      target="_blank"
+    >
       {{ tagName }}
-    </span>
+    </a>
   </div>
 </template>
 
@@ -15,6 +21,11 @@ export default {
       required: false,
       default: "",
     },
+    isLabelVisible: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
     tagLabel: {
       type: String,
       required: false,
@@ -26,14 +37,26 @@ export default {
       default: "Default",
     },
   },
+  data() {
+    return {
+      tagUrl: `https://stackoverflow.com/questions/tagged/${this.tagName}`,
+    };
+  },
 };
 </script>
 
 <style scoped lang="scss">
-.tag_value {
-  background: #808080;
-  border-radius: 10px;
-  color: rgb(216, 216, 216);
-  text-align: center;
+.tag {
+  &_value {
+    background: #808080;
+    border-radius: 10px;
+    color: #d8d8d8;
+    text-align: center;
+    text-decoration: none;
+    &:hover {
+      color: #959494;
+      transition: all 0.2s ease-in-out;
+    }
+  }
 }
 </style>


### PR DESCRIPTION
Fixes: ([issue](https://github.com/Manuel-Suarez-Abascal/stackoverNotifier/issues/30))

# Description

Added `href's URL` to `BaseTag.vue` component to be able to navigate to the click tag on Stackoverflow page.


**BEFORE**:
[insert screenshot/GIF here]

**AFTER**:

https://user-images.githubusercontent.com/32891808/119214441-e384f600-ba94-11eb-9a28-828dc98f7f44.mov

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Migration & dependencies update


# Checklist:

- [X] My code follows the style guidelines of this project (ESLint + Prettier)
- [X] I have added/updated the corresponding unit & E2E tests
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if applicable)
- [X] My changes generate no new warnings